### PR TITLE
Remove pyconfig as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 version = '0.13dev'
 
-install_requires = [
-    'lxml',
-]
+install_requires = []
 
 # Let some other project depend on 'xmlsec[PKCS11]'
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 version = '0.13dev'
 
 install_requires = [
-    'lxml', 'pyconfig'
+    'lxml',
 ]
 
 # Let some other project depend on 'xmlsec[PKCS11]'


### PR DESCRIPTION
Previous changes removed the use of pyconfig, now remove from dependencies so that we can install via pip.
